### PR TITLE
Parameter call refactor

### DIFF
--- a/widgets/gui/qt_left_window.py
+++ b/widgets/gui/qt_left_window.py
@@ -65,7 +65,7 @@ class LeftWindow(QWidget):
         self.grid_layout.addWidget(self.toggle_button, self.row_counter, 0, 1, 5)
 
     @property
-    def fetch_parameters(self):
+    def parameters(self):
         parameter_vals = {}
         for i in range(0, len(self.parameter_objects)):
             parameter_vals[self.parameter_objects[i].label.text()] = self.parameter_objects[i].spinbox.value()

--- a/widgets/gui/qt_left_window.py
+++ b/widgets/gui/qt_left_window.py
@@ -66,8 +66,8 @@ class LeftWindow(QWidget):
 
     @property
     def update_parameters(self):
-        parameter_vals = []
-        for i in range(0, 14):
-            parameter_vals.append(self.parameter_objects[i].spinbox.value())
+        parameter_vals = {}
+        for i in range(0, len(self.parameter_objects)):
+            parameter_vals[self.parameter_objects[i].label.text()] = self.parameter_objects[i].spinbox.value()
 
         return parameter_vals

--- a/widgets/gui/qt_left_window.py
+++ b/widgets/gui/qt_left_window.py
@@ -65,7 +65,7 @@ class LeftWindow(QWidget):
         self.grid_layout.addWidget(self.toggle_button, self.row_counter, 0, 1, 5)
 
     @property
-    def update_parameters(self):
+    def fetch_parameters(self):
         parameter_vals = {}
         for i in range(0, len(self.parameter_objects)):
             parameter_vals[self.parameter_objects[i].label.text()] = self.parameter_objects[i].spinbox.value()

--- a/widgets/gui/qt_live_control.py
+++ b/widgets/gui/qt_live_control.py
@@ -2,7 +2,9 @@ from PyQt5.QtWidgets import QWidget, QApplication, QComboBox, QPushButton, QVBox
 from PyQt5.QtCore import Qt, pyqtSignal, QRunnable, QThreadPool, pyqtSlot
 import time
 import logging
+
 from widgets.gui.qt_nidaq_worker import NIDaqWorker
+from widgets.hardware.alternative_control import NIdaq
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 
@@ -64,15 +66,7 @@ class LiveControl(QWidget):
                 QApplication.processEvents()
             self.wait_shutdown = True  # reset to true for next call
 
-            parameters = self.parent.left_window.update_parameters
-            view = self.view_combobox.currentText()
-            channel = self.laser_combobox.currentText()
-
-            print("called with:", parameters, view, "and channel", channel)
-
-            # launch worker thread with newest parameters
-
-            daq_card_worker = NIDaqWorker(self.live_worker, [parameters, view, channel])
+            daq_card_worker = NIDaqWorker(self.live_worker)
 
             # connect
             daq_card_worker.signals.running.connect(self.status_running)
@@ -86,10 +80,12 @@ class LiveControl(QWidget):
             if not self.state_tracker:
                 self.trigger_stop_live.emit()
 
-    def live_worker(self, parent_worker, args):
-        parameters = args[0]
-        view = int(args[1][5])
-        channel = int(args[2])
+    def live_worker(self, parent_worker):
+        parameters = self.parent.left_window.update_parameters
+        view = self.fetch_combobox_view
+        channel = self.fetch_combobox_channel
+
+        print("called with:", parameters, view, "and channel", channel)
 
         while True:
             time.sleep(1)
@@ -97,22 +93,7 @@ class LiveControl(QWidget):
             if not parent_worker.thread_running:
                 break
 
-        # self.daq_card = NIdaq(self,
-        #                      exposure=self.parameters[0],
-        #                      nb_timepoints=self.parameters[1],
-        #                      scan_step=self.parameters[2],
-        #                      stage_scan_range=self.parameters[3],
-        #                      vertical_pixels=self.parameters[4],
-        #                      num_samples=self.parameters[5],
-        #                      offset_view1=self.parameters[6],
-        #                      offset_view2=self.parameters[7],
-        #                      view1_galvo1=self.parameters[8],
-        #                      view1_galvo2=self.parameters[9],
-        #                      view2_galvo1=self.parameters[10],
-        #                      view2_galvo2=self.parameters[11],
-        #                      stripe_reduction_range=self.parameters[12],
-        #                      stripe_reduction_offset=self.parameters[13])
-        #
+        # self.daq_card = NIdaq(self, **parameters)
         # self.daq_card.select_view(view)
         # self.daq_card.select_channel_remove_stripes(channel)
 
@@ -137,3 +118,11 @@ class LiveControl(QWidget):
 
     def update_wait_shutdown(self):
         self.wait_shutdown = False
+
+    @property
+    def fetch_combobox_view(self):
+        return self.view_combobox.currentIndex() + 1
+
+    @property
+    def fetch_combobox_channel(self):
+        return int(self.laser_combobox.currentText())

--- a/widgets/gui/qt_live_control.py
+++ b/widgets/gui/qt_live_control.py
@@ -81,9 +81,9 @@ class LiveControl(QWidget):
                 self.trigger_stop_live.emit()
 
     def live_worker(self, parent_worker):
-        parameters = self.parent.left_window.fetch_parameters
-        view = self.fetch_combobox_view
-        channel = self.fetch_combobox_channel
+        parameters = self.parent.left_window.parameters
+        view = self.combobox_view
+        channel = self.combobox_channel
 
         print("called with:", parameters, view, "and channel", channel)
 
@@ -120,9 +120,9 @@ class LiveControl(QWidget):
         self.wait_shutdown = False
 
     @property
-    def fetch_combobox_view(self):
+    def combobox_view(self):
         return self.view_combobox.currentIndex() + 1
 
     @property
-    def fetch_combobox_channel(self):
+    def combobox_channel(self):
         return int(self.laser_combobox.currentText())

--- a/widgets/gui/qt_live_control.py
+++ b/widgets/gui/qt_live_control.py
@@ -81,7 +81,7 @@ class LiveControl(QWidget):
                 self.trigger_stop_live.emit()
 
     def live_worker(self, parent_worker):
-        parameters = self.parent.left_window.update_parameters
+        parameters = self.parent.left_window.fetch_parameters
         view = self.fetch_combobox_view
         channel = self.fetch_combobox_channel
 

--- a/widgets/gui/qt_nidaq_worker.py
+++ b/widgets/gui/qt_nidaq_worker.py
@@ -3,7 +3,6 @@ from PyQt5.QtCore import QRunnable, pyqtSlot
 # from widgets.hardware.alternative_control import NIdaq
 from widgets.gui.qt_worker_signals import WorkerSignals
 
-
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
@@ -30,5 +29,5 @@ class NIDaqWorker(QRunnable):
             self.signals.finished.emit()
 
     def stop(self):
-        #self.daq_card.stop_now = True
+        # self.daq_card.stop_now = True
         self.thread_running = False

--- a/widgets/gui/qt_timelapse_control.py
+++ b/widgets/gui/qt_timelapse_control.py
@@ -61,9 +61,9 @@ class TimelapseControl(QWidget):
             # emit final trigger_stop_live.emit before final worker is initialized, preventing a proper shutdown.
 
     def timelapse_worker(self, parent_worker):
-        parameters = self.parent.left_window.fetch_parameters
-        view = self.fetch_combobox_view
-        channel = self.fetch_combobox_channel
+        parameters = self.parent.left_window.parameters
+        view = self.combobox_view
+        channel = self.combobox_channel
 
         print("called with:", parameters, view, "and channel", channel)
 
@@ -90,9 +90,9 @@ class TimelapseControl(QWidget):
             self.trigger_stop_timelapse.emit()
 
     @property
-    def fetch_combobox_view(self):
+    def combobox_view(self):
         return self.view_combobox.currentIndex() + 1
 
     @property
-    def fetch_combobox_channel(self):
+    def combobox_channel(self):
         return int(self.laser_combobox.currentText())

--- a/widgets/gui/qt_timelapse_control.py
+++ b/widgets/gui/qt_timelapse_control.py
@@ -61,7 +61,7 @@ class TimelapseControl(QWidget):
             # emit final trigger_stop_live.emit before final worker is initialized, preventing a proper shutdown.
 
     def timelapse_worker(self, parent_worker):
-        parameters = self.parent.left_window.update_parameters
+        parameters = self.parent.left_window.fetch_parameters
         view = self.fetch_combobox_view
         channel = self.fetch_combobox_channel
 

--- a/widgets/gui/qt_timelapse_control.py
+++ b/widgets/gui/qt_timelapse_control.py
@@ -6,6 +6,7 @@ import logging
 from widgets.gui import qt_line_break
 from widgets.gui.qt_nidaq_worker import NIDaqWorker
 # from widgets.hardware.control import NIDaq
+from widgets.hardware.alternative_control import NIdaq
 
 
 class TimelapseControl(QWidget):
@@ -48,15 +49,8 @@ class TimelapseControl(QWidget):
     def launch_nidaq_instance(self):
         print("state_tracker", self.state_tracker)
         if self.state_tracker:
-
-            parameters = self.parent.left_window.update_parameters
-            view = self.view_combobox.currentText()
-            channel = self.laser_combobox.currentText()
-
-            print("called with:", parameters, view, "and channel", channel)
-
             # launch worker thread with newest parameters
-            daq_card_worker = NIDaqWorker(self.timelapse_worker, [parameters, view, channel])
+            daq_card_worker = NIDaqWorker(self.timelapse_worker)
 
             # connect
             self.trigger_stop_timelapse.connect(daq_card_worker.stop)
@@ -66,10 +60,12 @@ class TimelapseControl(QWidget):
             # because processEvents runs while waiting for wait_shutdown = False, if pressed quickly, live mode can
             # emit final trigger_stop_live.emit before final worker is initialized, preventing a proper shutdown.
 
-    def timelapse_worker(self, parent_worker, args):
-        parameters = args[0]
-        view = int(args[1][5])
-        channel = int(args[2])
+    def timelapse_worker(self, parent_worker):
+        parameters = self.parent.left_window.update_parameters
+        view = self.fetch_combobox_view
+        channel = self.fetch_combobox_channel
+
+        print("called with:", parameters, view, "and channel", channel)
 
         while True:
             time.sleep(1)
@@ -77,22 +73,7 @@ class TimelapseControl(QWidget):
             if not parent_worker.thread_running:
                 break
 
-        # self.daq_card = NIdaq(self,
-        #                      exposure=self.parameters[0],
-        #                      nb_timepoints=self.parameters[1],
-        #                      scan_step=self.parameters[2],
-        #                      stage_scan_range=self.parameters[3],
-        #                      vertical_pixels=self.parameters[4],
-        #                      num_samples=self.parameters[5],
-        #                      offset_view1=self.parameters[6],
-        #                      offset_view2=self.parameters[7],
-        #                      view1_galvo1=self.parameters[8],
-        #                      view1_galvo2=self.parameters[9],
-        #                      view2_galvo1=self.parameters[10],
-        #                      view2_galvo2=self.parameters[11],
-        #                      stripe_reduction_range=self.parameters[12],
-        #                      stripe_reduction_offset=self.parameters[13])
-        #
+        # self.daq_card = NIdaq(self, **parameters)
         # self.daq_card.select_view(view)
         # self.daq_card.select_channel_remove_stripes(channel)
 
@@ -107,3 +88,11 @@ class TimelapseControl(QWidget):
         else:
             self.section_button.setStyleSheet("")
             self.trigger_stop_timelapse.emit()
+
+    @property
+    def fetch_combobox_view(self):
+        return self.view_combobox.currentIndex() + 1
+
+    @property
+    def fetch_combobox_channel(self):
+        return int(self.laser_combobox.currentText())


### PR DESCRIPTION
- Property fetching latest parameter values now returns them as a dictionary, allowing it to be deserialized and passed when creating NIDaq instance.
- view and channel are now fetched by two properties (at runtime).
- Clutter of fetching parameter, view, channel in launch_nidaq(), passing into worker call, then passing into function call in run slot - replaced with single property call in function passed to worker.