### PR TITLE
Status Bar Changes

### DIFF
--- a/widgets/gui/qt_live_control.py
+++ b/widgets/gui/qt_live_control.py
@@ -120,12 +120,11 @@ class LiveControl(QWidget):
         self.state_tracker = not self.state_tracker
 
         if self.state_tracker:
-            self.section_button.setStyleSheet("background-color: red")
             self.launch_nidaq()
+            self.section_button.setStyleSheet("background-color: red")
         else:
-            self.section_button.setStyleSheet("")
             self.trigger_stop_live.emit()
-            self.parent.parent.status_bar.showMessage("NIDaq idle...")
+            self.section_button.setStyleSheet("")
 
     @pyqtSlot()
     def status_launching(self):
@@ -137,3 +136,6 @@ class LiveControl(QWidget):
 
     def update_wait_shutdown(self):
         self.wait_shutdown = False
+        # reset to idle status here to prevent 'running' being displayed if live mode exited while spinbox is selected
+        if not self.state_tracker:
+            self.parent.parent.status_bar.showMessage("NIDaq idle...")


### PR DESCRIPTION
Status bar would falsely displays 'NIDaq running...' if live mode was exited while spinbox was still selected. This is due a final call to create another NIDaq instance when live mode is disabled, as the spinbox triggers the editingFinished() signal. This causes an update to the status bar with a running message to be sent, after the idle message was sent. Fixed by Placing the call to idle in the update_wait_shutdown slot, which only triggers after the thread has gracefully shutdown.